### PR TITLE
[EPO-386] Jupyter performance

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
 set -e
 
+# Note: if you don't pull the latest image, docker build won't check
+# if there's a newer one.
+docker pull lsstsqre/jld-lab:latest
+
+# Build the image.
+# Note: the working directory is the base of the repo.  Also check
+# the .dockerignore to whitelist files to be included in the image. 
 docker build -t lsstepo/jupyterlab:dev -f ./jupyter-image/Dockerfile .

--- a/jupyter-image/Dockerfile
+++ b/jupyter-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsstsqre/jld-lab
+FROM lsstsqre/jld-lab:latest
 
 # Add our astropixie API library
 ADD astropixie /opt/astropixie


### PR DESCRIPTION
I noted that downloading a particular layer of the lsstsqre/jld-lab image
was very very slow.  All our epo images had the same base image, even done
on different days.  I then noticed that docker build wasn't checking the
registry for new images, which we want.  So I'm adding an extra pull
before the build to make sure we get the latest image.  I'm also setting
the tag to latest in the Dockerfile, although this still won't trigger
a check of the remote registry.