### PR TITLE
[EPO-406] Lock jupyterlab version to one that works with bokeh.

### DIFF
--- a/jupyter-image/Dockerfile
+++ b/jupyter-image/Dockerfile
@@ -1,4 +1,7 @@
-FROM lsstsqre/jld-lab:latest
+# EPO-406: We need to use the d20180111 image with jupyterlab where
+# it will render javascript for the bokeh graphs.
+#FROM lsstsqre/jld-lab:latest
+FROM lsstepo/jupyterlab:d20180111
 
 # Add our astropixie API library
 ADD astropixie /opt/astropixie

--- a/jupyter-image/bake.sh
+++ b/jupyter-image/bake.sh
@@ -6,5 +6,10 @@ set -e
 # Install astropixie API library
 sudo pip3 install /opt/astropixie
 
+# EPO-406 - We need to build on top of a previous EPO image
+# If we're building on top of a previous image, delete those notebooks
+# that may exist, so we can get a fresh copy without error.
+rm -rf /opt/hr-diagram-activity
+
 # Clone our educational notebooks
 git clone https://github.com/lsst-epo/hr-diagram-investigations.git /opt/hr-diagram-activity

--- a/jupyter-image/refreshnb.sh
+++ b/jupyter-image/refreshnb.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 set -e
 
+# Delete any previous user notebooks.
 rm -rf ~/notebooks
-ln -s /opt/hr-diagram-activity ~/notebooks
+
+# Make a copy of the notebooks.  This is better than a symlink
+# because the user will be able to modify and save in their own
+# home directory.
+cp -R /opt/hr-diagram-activity ~/notebooks


### PR DESCRIPTION
In later versions of jupyterlab, such as commit:
a29ab9a220ed133704bee0e098a002c913bd3194

Bokeh graphs will be prevented from loading with the error that
JavaScript output is disabled in JupyterLab.

Pin our image to the one that allows this, at least until the workshop.