### PR TITLE
[EPO-406] Back to current DM images.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 set -e
 
-# Note: if you don't pull the latest image, docker build won't check
-# if there's a newer one.
-docker pull lsstsqre/jld-lab:latest
-
 # Build the image.
 # Note: the working directory is the base of the repo.  Also check
 # the .dockerignore to whitelist files to be included in the image. 
-docker build -t lsstepo/jupyterlab:dev -f ./jupyter-image/Dockerfile .
+docker build --pull -t lsstepo/jupyterlab:dev -f ./jupyter-image/Dockerfile .

--- a/jupyter-image/Dockerfile
+++ b/jupyter-image/Dockerfile
@@ -1,7 +1,4 @@
-# EPO-406: We need to use the d20180111 image with jupyterlab where
-# it will render javascript for the bokeh graphs.
-#FROM lsstsqre/jld-lab:latest
-FROM lsstepo/jupyterlab:d20180111
+FROM lsstsqre/jld-lab:latest
 
 # Add our astropixie API library
 ADD astropixie /opt/astropixie

--- a/official_release.sh
+++ b/official_release.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+DAILY_RELEASE=${1?Did not provide daily release to promote}
+RELEASE_TAG=${2?Did not provide release to create}
+
+echo "Creating release $RELEASE_TAG from daily release $DAILY_RELEASE"
+
+docker tag lsstepo/jupyterlab:d$DAILY_RELEASE lsstepo/jupyterlab:r$RELEASE_TAG
+docker push lsstepo/jupyterlab:r$RELEASE_TAG


### PR DESCRIPTION
A few things happening in this commit:

1) build.sh - use --pull when building, rather than another docker command.
Does the same thing, but in a cleaner way.

2) jupyter-image/Dockerfile - go back to the latest lsstsqre images.

3) official_release.sh - new script to promote a daily release to
a release candidate by pushing new tags.  This will make it show up
in the spawner.