### PR TITLE
[EPO-382] Copy `notebooks` directory instead of entire repository.

### DIFF
--- a/jupyter-image/refreshnb.sh
+++ b/jupyter-image/refreshnb.sh
@@ -7,4 +7,4 @@ rm -rf ~/notebooks
 # Make a copy of the notebooks.  This is better than a symlink
 # because the user will be able to modify and save in their own
 # home directory.
-cp -R /opt/hr-diagram-activity ~/notebooks
+cp -R /opt/hr-diagram-activity/notebooks ~/notebooks


### PR DESCRIPTION
  * Fixes issue so local and deployed JupyterLabs use the same directory structure.

	modified:   jupyter-image/refreshnb.sh