### PR TITLE
[EPO-384] Use no-cache option when building daily images.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,4 +4,4 @@ set -e
 # Build the image.
 # Note: the working directory is the base of the repo.  Also check
 # the .dockerignore to whitelist files to be included in the image. 
-docker build --pull -t lsstepo/jupyterlab:dev -f ./jupyter-image/Dockerfile .
+docker build --no-cache --pull -t lsstepo/jupyterlab:dev -f ./jupyter-image/Dockerfile .


### PR DESCRIPTION
If we don't use no-cache, then we might not build the image if only
the notebooks (in another repo) changed.  So we should force the image
creation to be fresh and not use any caching.  If you want to use caching,
then copy paste the command and run it in your dev flow.