### PR TITLE
[EPO-467] Allow daily_release.sh to build different image chains.

### DIFF
--- a/daily_release.sh
+++ b/daily_release.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 set -e
 
+# In order to build a different image name, set
+# the environment variable IMAGE_NAME to what the
+# name you want to create is.  This is also used
+# as a parameter in the Jenkins job that calls this script.
+# By default, this is jupyterlab.
+IMAGE_NAME=${IMAGE_NAME:-'jupyterlab'}
+
 # Use the format YYYYMMDD (for example 20180124)
 # for the daily releases.  Pass it in on the command line,
 # or by default, use today's date.
 RELEASE_TAG=${1:-`date +%Y%m%d`}
-echo "Creating daily release $RELEASE_TAG"
+echo "Creating daily release lsstepo/$IMAGE_NAME:d$RELEASE_TAG"
 
-docker tag lsstepo/jupyterlab:dev lsstepo/jupyterlab:d$RELEASE_TAG
-docker push lsstepo/jupyterlab:d$RELEASE_TAG
+docker tag lsstepo/jupyterlab:dev lsstepo/$IMAGE_NAME:d$RELEASE_TAG
+docker push lsstepo/$IMAGE_NAME:d$RELEASE_TAG


### PR DESCRIPTION
By using $IMAGE_NAME, we can have daily_release.sh build different
chains of images with different names.  This allows for different
environments to listen for different names, which presents different
options to the spawner (and the user).