### PR TITLE
[EPO-520] Introduce a weekly cleanup job.

### DIFF
--- a/ops/jenkins/jobs/weekly_cleanup
+++ b/ops/jenkins/jobs/weekly_cleanup
@@ -1,0 +1,26 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>Weekly cleanup of docker and CI issues that may need to be reset.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <assignedNode>jenkins-jenkins-slave</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+    <hudson.triggers.TimerTrigger>
+      <spec>H H(3-7) * * 7</spec>
+    </hudson.triggers.TimerTrigger>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>docker system prune --all --force</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>


### PR DESCRIPTION
This will clean up our stale, old, and broken docker images that
are taking up a lot of disk space.  If we run out of disk space,
future builds may fail.