### PR TITLE
[EPO-544] Use external catalogs as sources of photometry and location.

### DIFF
--- a/astropixie-widgets/astropixie_widgets/visual.py
+++ b/astropixie-widgets/astropixie_widgets/visual.py
@@ -49,7 +49,7 @@ def _diagram(plot_figure, source=None, color='black', line_color='#444444',
     logging.info(type(source))
     logging.info(source)
     plot_figure.circle(x='x', y='y', source=source,
-                       size=8, color=color, alpha=1, name=name,
+                       size=4, color=color, alpha=1, name=name,
                        line_color=line_color, line_width=0.5)
     plot_figure.xaxis.axis_label = xaxis_label
     plot_figure.yaxis.axis_label = yaxis_label
@@ -194,6 +194,7 @@ def hr_diagram_figure(cluster):
     pf = figure(y_axis_type='log', x_range=x_range, name='hr',
                 tools='box_select,lasso_select,reset',
                 title='H-R Diagram for {0}'.format(cluster.name))
+    
     _diagram(source=source, plot_figure=pf, name='hr',
              color={'field': 'color', 'transform': color_mapper},
              xaxis_label='Temperature (Kelvin)',

--- a/astropixie-widgets/setup.py
+++ b/astropixie-widgets/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup
 
 setup(name='astropixie-widgets',
-      version='0.1.3',
+      version='0.1.4',
       description='LSST EPO ',
-      url='https://github.com/lsst-epo/vela/astropixie-hr',
+      url='https://github.com/lsst-epo/vela/astropixie-widgets',
       author='LSST EPO Team',
       author_email='epo-team@lists.lsst.org',
       license='MIT',
@@ -12,11 +12,11 @@ setup(name='astropixie-widgets',
       package_data={'astropixie': ['sample_data/*']},
       install_requires=[
           'astropixie',
-          'astropy==3.0.1',
+          'astropy>=3.0.1,<3.1',
           'astroquery',
           'bokeh>=0.12.15',
           # 'ipyaladin',
-          'numpy==1.14.2',
+          'numpy>=1.14.2,<1.16',
           'pandas',
           'pytest',
           'scipy'

--- a/astropixie/astropixie/__init__.py
+++ b/astropixie/astropixie/__init__.py
@@ -1,5 +1,5 @@
-import astropixie.catalog_service
-import astropixie.sample_catalog_provider
+from . import catalog_service
+from . import sample_catalog_provider
 
 from . import data
 
@@ -7,5 +7,5 @@ def hello_universe():
     return "Hello universe!"
 
 
-provider = astropixie.sample_catalog_provider.SampleCatalogProvider()
-Catalog = astropixie.catalog_service.CatalogService(provider)
+provider = sample_catalog_provider.SampleCatalogProvider()
+Catalog = catalog_service.CatalogService(provider)

--- a/astropixie/setup.py
+++ b/astropixie/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='astropixie',
-      version='0.1.3',
+      version='0.1.4',
       description='LSST EPO python library.',
       url='https://github.com/lsst-epo/vela/astropixie',
       author='LSST EPO Team',
@@ -11,8 +11,8 @@ setup(name='astropixie',
       include_package_data=True,
       package_data={'astropixie': ['sample_data/*']},
       install_requires=[
-          'astropy',
-          'numpy',
-          'pandas',
-          'pytest'
+          'astropy>=3.0.1,<3.1',
+          'numpy>=1.14,<1.15',
+          'pandas>=0.22,<0.23',
+          'pytest>=3.5,<3.6'
       ])


### PR DESCRIPTION
  * Add `SDSSRegion` to `astropixie.data` module. Supports `astroquery.sdss.SDSS`
    astropy tables.
  * Change imports in `astropixie/__init__.py` to be relative.
  * Increment version of astropixie and astropixie-widgets
  * Reduce size of points on H-R diagram widget.

	modified:   astropixie-widgets/astropixie_widgets/visual.py
	modified:   astropixie-widgets/setup.py
	modified:   astropixie/astropixie/__init__.py
	modified:   astropixie/astropixie/data.py
	modified:   astropixie/setup.py