### PR TITLE
[EPO-604] Install hide_code from github, not npm.

### DIFF
--- a/jupyter-image/bake.sh
+++ b/jupyter-image/bake.sh
@@ -31,7 +31,9 @@ pip install /opt/astropixie
 pip install /opt/astropixie-widgets
 
 # Install our own EPO extensions.
-jupyter labextension install jupyterlab_hidecode --no-build
+git clone https://github.com/lsst-epo/jupyterlab_hidecode.git /opt/hide_code
+(cd /opt/hide_code && npm install && npm run build)
+jupyter labextension link /opt/hide_code
 
 # Final build
 jupyter lab clean
@@ -40,3 +42,4 @@ jupyter lab build
 # Clone our educational notebooks
 git clone https://github.com/lsst-epo/investigations.git /opt/investigations
 cp -r /opt/investigations ~jovyan/investigations
+chown -R jovyan ~jovyan/investigations


### PR DESCRIPTION
The npm version doesn't seem to work as well as the github one, and
by installing it from github it will never be out of date.

Also, fix the permissions on the investigations directory, otherwise
people will get strange errors trying to save their notebooks.  It's
just a copy anyway.