### PR TITLE
[EPO-634] Question widget first attempt.

### DIFF
--- a/astropixie-widgets/astropixie_widgets/question.py
+++ b/astropixie-widgets/astropixie_widgets/question.py
@@ -1,0 +1,9 @@
+import ipywidgets
+
+def show_question(questionText, rows=1):
+    css = ipywidgets.HTML('<style>.widget-label{white-space:normal; overflow:auto}</style>')
+    layout = ipywidgets.Layout(width='95%', height='100%')
+    label = ipywidgets.Label(questionText, layout=layout)
+    answer = ipywidgets.Textarea(rows=rows, layout=layout)
+    box = ipywidgets.VBox(children=[css, label, answer])
+    display(box)


### PR DESCRIPTION
This wraps the logic to make a question box, and provides just one
call with the text and the number of rows for the answer box.  This
at least gets all the creation in one place (and out of the notebook).

This will help us later refactor the questions into saving the answers
to a remote database.

This also contains some CSS to make sure that the text wraps appropriately.
Thanks Abbey!