### PR TITLE
[EPO-643] Use index instead of id with SDSS data.

### DIFF
--- a/astropixie-widgets/astropixie_widgets/visual.py
+++ b/astropixie-widgets/astropixie_widgets/visual.py
@@ -477,7 +477,7 @@ WHERE p.clean = 1 and p.probPSF = 1
         self.pf.select(LassoSelectTool).select_every_mousemove = False
         self.pf.select(LassoSelectTool).select_every_mousemove = False
         hover = self.pf.select(HoverTool)[0]
-        hover.tooltips = [("id", "@id{0}"),
+        hover.tooltips = [("index", "@index{0}"),
                           ("Temperature (Kelvin)", "@x{0}"),
                           ("Luminosity (solar units)", "@y{0.00}")]
         self.session = self.pf.circle(x='x', y='y', source=source,


### PR DESCRIPTION
  * It may make sense to just use nothing. But the index can still be correlated
    in a table, so it seems better than nothing. The ids are int64s and might
    as well be UUIDs. They only hod value in providing uniqueness and otherwise are
    confusing and don't fit.

	modified:   astropixie-widgets/astropixie_widgets/visual.py