### PR TITLE
[EPO-827] Fix index in hover tool.

### DIFF
--- a/astropixie-widgets/astropixie_widgets/visual.py
+++ b/astropixie-widgets/astropixie_widgets/visual.py
@@ -495,7 +495,7 @@ WHERE p.clean = 1 and p.probPSF = 1
         self.pf.select(LassoSelectTool).select_every_mousemove = False
         self.pf.select(LassoSelectTool).select_every_mousemove = False
         hover = self.pf.select(HoverTool)[0]
-        hover.tooltips = [("index", "@index{0}"),
+        hover.tooltips = [("index", "$index{0}"),
                           ("Temperature (Kelvin)", "@x{0}"),
                           ("Luminosity (solar units)", "@y{0.00}")]
         self.session = self.pf.circle(x='x', y='y', source=source,


### PR DESCRIPTION
  * Use $ instead of @ since index is a built-in variable not
    part of the source.

	modified:   astropixie-widgets/astropixie_widgets/visual.py