### PR TITLE
[EPO-881] Disable idle culler to see if that helps login problem.

### DIFF
--- a/ops/jupyterhub/hub-template.yaml
+++ b/ops/jupyterhub/hub-template.yaml
@@ -6,6 +6,8 @@ hub:
     c.JupyterHub.log_level = 'DEBUG'
     c.Spawner.debug = True
     c.LocalProcessSpawner.debug = True
+cull:
+  enabled: false
 singleuser:
   image:
     name: lsstepo/jupyterlab


### PR DESCRIPTION
On another test environment I've set up without the idle culler,
I don't seem to see the problem.  Let's try that out for a few
days on sandbox and see if that helps.

Even if it doesn't, being able to login users for the focus group
ahead of time and not having them be culled for idleness will help
ensure that everyone can get to the notebooks until this is resolved.