### PR TITLE
[EPO-971] Pin versions of minimal-notebook and jupyterlab-manager.

### DIFF
--- a/jupyter-image/Dockerfile
+++ b/jupyter-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/minimal-notebook:latest
+FROM jupyter/minimal-notebook:e7000ca1416d
 
 # Add our astropixie API library
 ADD astropixie /opt/astropixie

--- a/jupyter-image/bake.sh
+++ b/jupyter-image/bake.sh
@@ -24,7 +24,7 @@ pip install git+https://github.com/jupyterhub/nbserverproxy
 jupyter serverextension enable --py nbserverproxy
 
 # Install jupyter extensions.
-jupyter labextension install @jupyter-widgets/jupyterlab-manager --no-build
+jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.35 --no-build
 
 # Install astropixie API library
 pip install -e /opt/astropixie


### PR DESCRIPTION
We just had a break, where there was a newer version of jupyterlab-manager
(0.36) which was installed by default by the line in the bake.sh script.

This version is incompatible with the version of jupyterlab already
pre-installed in the minimal-notebook container.

What I've done is explicitly install a version 0.35, which is the compatible
version, and also pin the version of the notebook container.  The notebook
container recently had a couple of annoyances which aren't in this older version.

Those simple annoyances are that vim is no longer being installed by default,
and I love vim, as well as the URL that is printed out has some random address
instead of localhost, which makes it harder to click on.  Other than that, this
should tide us over until we want to make the jump to a different jupyter version.