### PR TITLE
[EPO-980] Increase time to 5 seconds before loading catalog into skyv…

### DIFF
--- a/astropixie-widgets/astropixie_widgets/visual.py
+++ b/astropixie-widgets/astropixie_widgets/visual.py
@@ -610,7 +610,7 @@ class SHRD():
             show_with_bokeh_server(self._show_hr_diagram, output=output)
             box = self._box(output)
             widgets.widget.display(box,layout=widgets.Layout(width='auto'))
-            time.sleep(0.8)
+            time.sleep(5)
             self.aladin.add_table(self.cluster.table)
         else:
             widgets.widget.display(self.aladin)


### PR DESCRIPTION
…iewer.

For the workshop, the last thing I want is for people to hit this
race condition.  It's not ideal, but I'd rather spend a few extra
seconds in loading time than to have to coach people in how to
restart the kernels and reload the notebooks.

This can be taken out when a better solution is implemented, which
I talked about in the associated ticket.